### PR TITLE
Floating score wrong spawn big fixed

### DIFF
--- a/Assets/Prefabs/FloatingScore.prefab
+++ b/Assets/Prefabs/FloatingScore.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 25.508, y: -180, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.015911, y: 0.56364}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &7168543809469076967
@@ -187,7 +187,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   screenTime: 1
-  placement: {x: 0, y: 0.1, z: 0.2}
 --- !u!95 &-4069678048404539700
 Animator:
   serializedVersion: 5

--- a/Assets/Scripts/FloatingScore.cs
+++ b/Assets/Scripts/FloatingScore.cs
@@ -5,17 +5,9 @@ using UnityEngine;
 public class FloatingScore : MonoBehaviour
 {
     public float screenTime = 1f;
-    public Vector3 placement = new Vector3(0, 2, 0); 
     // Start is called before the first frame update
     void Start()
     {
         Destroy(gameObject, screenTime);
-        transform.localPosition += placement;
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
     }
 }

--- a/Assets/Scripts/Indicator.cs
+++ b/Assets/Scripts/Indicator.cs
@@ -141,14 +141,14 @@ public class Indicator : MonoBehaviour
             splashEffect.Play();
             SoundEffects.PlayAudioClip(audioSource, catchClipArray, (int)actionIndex);
             score.addScore(currentFish.beatOfThisNote); // Calls score system to work
-            score.ShowFloatingScore(this.transform.position);
+            score.ShowFloatingScore(transform);
             Destroy(currentFish.gameObject);
             currentFish = null;
         }
         else
         {
             // Miss
-            score.ShowMissMessage(this.transform.position);
+            score.ShowMissMessage(transform);
             SoundEffects.PlayAudioClipAtRandom(audioSource, missClipArray);
             score.multiplier = 1; //If you press a button when there isn't any fish, multiplier resets
         }

--- a/Assets/Scripts/ScoreSystem.cs
+++ b/Assets/Scripts/ScoreSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using TMPro;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Audio;
 using UnityEngine.UIElements;
@@ -20,7 +21,9 @@ public class Score : MonoBehaviour
     [SerializeField] private AudioSource audio;
     [SerializeField] private Conductor conductor; // We need data from this to make the perfect detection
     private Fish fish;           // We need data from this to make the perfect detection
-    
+
+    [SerializeField] private Vector3 messageOffset = new Vector3(0, 0, 0.25f);
+
     private void Awake()
     {
         if (Instance != null)
@@ -67,15 +70,15 @@ public class Score : MonoBehaviour
 
     }
 
-    public void ShowFloatingScore(Vector3 v)
+    public void ShowFloatingScore(Transform spawnPoint)
     {
-        var fs = Instantiate(FloatingScore, v, Quaternion.Euler(0, -180, 0), transform);
+        var fs = Instantiate(FloatingScore, spawnPoint.position+messageOffset, Quaternion.Euler(0, -180, 0));
         fs.GetComponent<TextMeshPro>().text = accuracyTxt;
     }
 
-    public void ShowMissMessage(Vector3 v)
+    public void ShowMissMessage(Transform spawnPoint)
     {
-        var Mmsj = Instantiate(FloatingScore, v, Quaternion.Euler(0, -180, 0), transform);
+        var Mmsj = Instantiate(FloatingScore, spawnPoint.position + messageOffset, Quaternion.Euler(0, -180, 0));
         Mmsj.GetComponent<TextMeshPro>().text = "Miss!";
     }
 


### PR DESCRIPTION
The labels for miss, good and perfect timing were spawning at wrong position.

Bug fixed.

Closes #75 